### PR TITLE
enhancement: classes for article cards

### DIFF
--- a/wp-content/themes/vf-wp-sis/partials/vf-featured-articles.php
+++ b/wp-content/themes/vf-wp-sis/partials/vf-featured-articles.php
@@ -45,8 +45,8 @@ function wpml_content_languages($args = '')
         $post = get_field('featured_article_understand');
         setup_postdata($post);
         ?>
-        <article class="vf-card vf-card--brand vf-card--bordered">
-            <span class="vf-badge vf-badge--secondary" style="color: #fff;">Understand</span>
+        <article class="vf-card vf-card--brand vf-card--bordered sis-article-understand">
+            <span class="vf-badge sis-badge--understand">Understand</span>
             <?php the_post_thumbnail('full', array('class' => 'vf-card__image')); ?>
             <div class="vf-card__content | vf-stack vf-stack--400">
 
@@ -106,9 +106,8 @@ function wpml_content_languages($args = '')
         $post = get_field('featured_article_inspire');
         setup_postdata($post);
         ?>
-        <article class="vf-card vf-card--brand vf-card--bordered">
-                <span class="vf-badge vf-badge--primary"
-                      style="background: orange; border-color: orange;">Inspire</span>
+        <article class="vf-card vf-card--brand vf-card--bordered sis-article-inspire">
+            <span class="vf-badge sis-badge--inspire">Inspire</span>
             <?php the_post_thumbnail('full', array('class' => 'vf-card__image')); ?>
             <div class="vf-card__content | vf-stack vf-stack--400">
 
@@ -168,8 +167,8 @@ function wpml_content_languages($args = '')
         $post = get_field('featured_article_teach');
         setup_postdata($post);
         ?>
-        <article class="vf-card vf-card--brand vf-card--bordered">
-            <span class="vf-badge vf-badge--primary">Teach</span>
+        <article class="vf-card vf-card--brand vf-card--bordered sis-article-teach">
+            <span class="vf-badge sis-badge--teach">Teach</span>
             <?php the_post_thumbnail('full', array('class' => 'vf-card__image')); ?>
             <div class="vf-card__content | vf-stack vf-stack--400">
 

--- a/wp-content/themes/vf-wp-sis/partials/vf-front-collectionArticleType.php
+++ b/wp-content/themes/vf-wp-sis/partials/vf-front-collectionArticleType.php
@@ -4,15 +4,15 @@
     $articleTypesArray = sis_getArticleTypesArray();
     if($articleType == $articleTypesArray['UNDERSTAND']){
         ?>
-        <span class="vf-badge vf-badge--secondary" style="border-color: #8dd13e; background: #8dd13e; color: #fff;">Understand</span>
+        <span class="vf-badge sis-badge--understand">Understand</span>
         <?php
     } else if($articleType == $articleTypesArray['INSPIRE']){
         ?>
-        <span class="vf-badge vf-badge--primary" style="background: orange; border-color: orange;">Inspire</span>
+        <span class="vf-badge sis-badge--inspire">Inspire</span>
         <?php
     } else {
         ?>
-        <span class="vf-badge vf-badge--primary">Teach</span>
+        <span class="vf-badge sis-badge--teach">Teach</span>
         <?php
     }
     ?>

--- a/wp-content/themes/vf-wp-sis/partials/vf-front-currentIssueArticleTeaser.php
+++ b/wp-content/themes/vf-wp-sis/partials/vf-front-currentIssueArticleTeaser.php
@@ -5,15 +5,15 @@
     $articleTypesArray = sis_getArticleTypesArray();
     if($articleType == $articleTypesArray['UNDERSTAND']){
         ?>
-        <span class="vf-badge vf-badge--secondary" style="border-color: #8dd13e; background: #8dd13e; color: #fff;">Understand</span>
+        <span class="vf-badge sis-badge--understand">Understand</span>
         <?php
     } else if($articleType == $articleTypesArray['INSPIRE']){
         ?>
-        <span class="vf-badge vf-badge--primary" style="background: orange; border-color: orange;">Inspire</span>
+        <span class="vf-badge sis-badge--inspire">Inspire</span>
         <?php
     } else {
         ?>
-        <span class="vf-badge vf-badge--primary">Teach</span>
+        <span class="vf-badge sis-badge--teach">Teach</span>
         <?php
     }
     ?>

--- a/wp-content/themes/vf-wp-sis/partials/vf-front-discoverArticleTypes.php
+++ b/wp-content/themes/vf-wp-sis/partials/vf-front-discoverArticleTypes.php
@@ -1,8 +1,8 @@
 <!-- article types -->
 <section class="vf-grid vf-grid__col-3">
-    <article class="vf-card vf-card--brand vf-card--striped">
+    <article class="vf-card vf-card--brand vf-card--striped sis-article-understand">
         <img
-                src="https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/assets/emblstatic-homepage/assets/topics/structures.png"
+                src="https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/science-in-school-card_tunderstand_element.jpg"
                 alt="Image alt text" class="vf-card__image" loading="lazy">
         <div class="vf-card__content | vf-stack vf-stack--400">
             <h3 class="vf-card__heading"><a class="vf-card__link" href="/?sis-article-types=understand">Understand
@@ -19,9 +19,9 @@
             <p class="vf-card__text">Explore research and science topics</p>
         </div>
     </article>
-    <article class="vf-card vf-card--brand vf-card--striped">
+    <article class="vf-card vf-card--brand vf-card--striped sis-article-inspire">
         <img
-                src="https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/assets/emblstatic-homepage/assets/topics/structures.png"
+                src="https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/science-in-school-card_inspire_element.jpg"
                 alt="Image alt text" class="vf-card__image" loading="lazy">
         <div class="vf-card__content | vf-stack vf-stack--400">
             <h3 class="vf-card__heading"><a class="vf-card__link" href="/?sis-article-types=inspire">Inspire
@@ -38,9 +38,9 @@
             <p class="vf-card__text">Discover people, events and resources</p>
         </div>
     </article>
-    <article class="vf-card vf-card--brand vf-card--striped">
+    <article class="vf-card vf-card--brand vf-card--striped sis-article-teach">
         <img
-                src="https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/assets/emblstatic-homepage/assets/topics/structures.png"
+                src="https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/science-in-school-card_teach_element.jpg"
                 alt="Image alt text" class="vf-card__image" loading="lazy">
         <div class="vf-card__content | vf-stack vf-stack--400">
             <h3 class="vf-card__heading"><a class="vf-card__link" href="/?sis-article-types=teach">Teach

--- a/wp-content/themes/vf-wp-sis/partials/vf-front-featureArticleType.php
+++ b/wp-content/themes/vf-wp-sis/partials/vf-front-featureArticleType.php
@@ -4,15 +4,15 @@
         $articleTypesArray = sis_getArticleTypesArray();
         if($articleType == $articleTypesArray['UNDERSTAND']){
         ?>
-    <span class="vf-badge vf-badge--secondary" style="border-color: #8dd13e; background: #8dd13e; color: #fff;">Understand</span>
+    <span class="vf-badge sis-badge--understand">Understand</span>
     <?php
         } else if($articleType == $articleTypesArray['INSPIRE']){
     ?>
-            <span class="vf-badge vf-badge--primary" style="background: orange; border-color: orange;">Inspire</span>
+            <span class="vf-badge sis-badge--inspire">Inspire</span>
     <?php
         } else {
     ?>
-            <span class="vf-badge vf-badge--primary">Teach</span>
+            <span class="vf-badge sis-badge--teach">Teach</span>
     <?php
         }
     ?>

--- a/wp-content/themes/vf-wp-sis/partials/vf-issue-articleTeaser.php
+++ b/wp-content/themes/vf-wp-sis/partials/vf-issue-articleTeaser.php
@@ -9,19 +9,19 @@ $art_ages = get_field('art_ages');
     $articleTypesArray = sis_getArticleTypesArray();
     if($articleType == $articleTypesArray['UNDERSTAND']){
         ?>
-        <span class="vf-badge vf-badge--secondary" style="border-color: #8dd13e; background: #8dd13e; color: #fff;">Understand</span>
+        <span class="vf-badge sis-badge--understand">Understand</span>
         <?php
     } else if($articleType == $articleTypesArray['INSPIRE']){
         ?>
-        <span class="vf-badge vf-badge--primary" style="background: orange; border-color: orange;">Inspire</span>
+        <span class="vf-badge sis-badge--inspire">Inspire</span>
         <?php
     } else if($articleType == $articleTypesArray['EDITORIAL']){
         ?>
-        <span class="vf-badge vf-badge--primary" style="background: #000; border-color: #000; color:#fff;">Editorial</span>
+        <span class="vf-badge sis-badge--editorial">Editorial</span>
         <?php
     } else {
         ?>
-        <span class="vf-badge vf-badge--primary">Teach</span>
+        <span class="vf-badge sis-badge--teach">Teach</span>
         <?php
     }
     ?>
@@ -44,9 +44,7 @@ $art_ages = get_field('art_ages');
             <?php sis_printTagsWithHeaderAndEnd('Ages: ', $art_ages, '; ');?>
             <?php sis_printTagsWithHeaderAndEnd('Keywords: ', $art_editor_tags, '');?>
             <br/>
-
             <?php sis_articleLanguageSwitcherInLoop(); ?>
-
         </p>
     </div>
 </article>


### PR DESCRIPTION
This drops the temporary inline styling for cards (like `background: orange; border-color: orange`) and adds classes `sis-badge--inspire`.

It also updates the card images on the homepage.

I'll write the styling CSS in a separate PR, so things will look temporarily broken.

For #216