### PR TITLE
Feature: vf-card classes

### DIFF
--- a/wp-content/themes/vf-wp-sis/partials/vf-front-featureArticleType.php
+++ b/wp-content/themes/vf-wp-sis/partials/vf-front-featureArticleType.php
@@ -1,29 +1,23 @@
-<article class="vf-card vf-card--brand vf-card--bordered">
-    <?php
-        $articleType = get_field('art_article_type');
-        $articleTypesArray = sis_getArticleTypesArray();
-        if($articleType == $articleTypesArray['UNDERSTAND']){
-        ?>
-    <span class="vf-badge sis-badge--understand">Understand</span>
-    <?php
-        } else if($articleType == $articleTypesArray['INSPIRE']){
-    ?>
-            <span class="vf-badge sis-badge--inspire">Inspire</span>
-    <?php
-        } else {
-    ?>
-            <span class="vf-badge sis-badge--teach">Teach</span>
-    <?php
-        }
-    ?>
+<?php
+    $articleType = get_field('art_article_type');
+    $articleTypesArray = sis_getArticleTypesArray();
+    if($articleType == $articleTypesArray['UNDERSTAND']){
+        $articleTypeLabel = 'Understand';
+    } else if($articleType == $articleTypesArray['INSPIRE']){ 
+        $articleTypeLabel = 'Inspire';
+    } else {
+        $articleTypeLabel = 'Teach';
+    }
+?>
+<article class="vf-card vf-card--brand vf-card--bordered  sis-article-<?php print strtolower($articleTypeLabel); ?>">
+    <span class="vf-badge sis-badge--<?php print strtolower($articleTypeLabel); ?>"><?php print $articleTypeLabel; ?></span>
     <img src="<?php echo get_the_post_thumbnail_url(); ?>"
          alt="Image alt text" class="vf-card__image" loading="lazy">
     <div class="vf-card__content | vf-stack vf-stack--400">
         <h3 class="vf-card__heading"><a class="vf-card__link" href="<?php echo get_the_permalink(); ?>"><?php echo get_the_title(); ?>
                 <svg
                         aria-hidden="true" class="vf-card__heading__icon | vf-icon vf-icon-arrow--inline-end"
-                        width="1em"
-                        height="1em" xmlns="http://www.w3.org/2000/svg">
+                        width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
                     <path
                             d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z"
                             fill="currentColor" fill-rule="nonzero"></path>


### PR DESCRIPTION
This pull request makes it so the featured article card borders have the right colour by:

1. adding a needed class to `<article class="vf-card` of `sis-article-TYPE`
2. doing a little php cleanup, since we now need to echo the class twice in this template

@alexk1204:

1. Can you please check my code (i've not run locally)
2. We'll need to do similarly for "Our latest issue" and any other places we're using cards

For #216